### PR TITLE
グループ名とメンバーの表示

### DIFF
--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -2,9 +2,10 @@
   .main-header
     .main-header__left-box
       %h2.main-header__left-box__current-group 
-        groupname
+        = @group.name
       %ul.main-header__left-box__member-list 
-        Member: username
+        Member:
+        - @group.group_users.each do |group_user|
     = link_to "#" do
       .main-header__edit-btn Edit
   .messages


### PR DESCRIPTION
# what
メイン画面にグループ名とメンバーを表示させる
# why
グループ名とメンバーを明示的にするため